### PR TITLE
finished mocked create renderer impl and first test cases

### DIFF
--- a/fakes/opengl.go
+++ b/fakes/opengl.go
@@ -1,4 +1,4 @@
-package mocks
+package fakes
 
 import "github.com/leedenison/gologo/opengl"
 

--- a/mocks/opengl.go
+++ b/mocks/opengl.go
@@ -1,0 +1,20 @@
+package mocks
+
+import "github.com/leedenison/gologo/opengl"
+
+// CreateVerticesOnlyMeshRendererImpl : Creates a MeshRenderer that only
+// contains vertices and a vertexCount. All other values are nil or 0
+func CreateVerticesOnlyMeshRendererImpl(
+	vertexShader string,
+	fragmentShader string,
+	uniforms []int,
+	uniformValues map[int]interface{},
+	meshVertices []float32) (*opengl.MeshRenderer, error) {
+	return &opengl.MeshRenderer{
+		Shader:       nil,
+		Mesh:         0,
+		Uniforms:     nil,
+		MeshVertices: meshVertices,
+		VertexCount:  int32(len(meshVertices) / opengl.GlMeshStride),
+	}, nil
+}

--- a/opengl/opengl.go
+++ b/opengl/opengl.go
@@ -316,7 +316,7 @@ func (r *MeshRenderer) Clone() render.Renderer {
 	}
 }
 
-// CreateMeshRenderer : Creates a MeshRenderer.  uniforms specifies all uniform variable locations that
+// CreateMeshRendererImpl : Creates a MeshRenderer.  uniforms specifies all uniform variable locations that
 // should be bound in the shader program, including both uniforms with a statically
 // defined value and those supplied in each call to RenderAt.  uniformValues
 // specifies static values for some or all of the uniforms.

--- a/physics_test.go
+++ b/physics_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/go-gl/mathgl/mgl32"
-	"github.com/leedenison/gologo/mocks"
+	"github.com/leedenison/gologo/fakes"
 	"github.com/leedenison/gologo/opengl"
 )
 
@@ -118,7 +118,7 @@ func TestCircleFromRenderer(t *testing.T) {
 	var renderer *opengl.MeshRenderer
 	var err error
 
-	opengl.CreateMeshRenderer = mocks.CreateVerticesOnlyMeshRendererImpl
+	opengl.CreateMeshRenderer = fakes.CreateVerticesOnlyMeshRendererImpl
 
 	for _, tc := range circleFromRendererTests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/physics_test.go
+++ b/physics_test.go
@@ -4,49 +4,130 @@ import (
 	"testing"
 
 	"github.com/go-gl/mathgl/mgl32"
+	"github.com/leedenison/gologo/mocks"
+	"github.com/leedenison/gologo/opengl"
 )
 
 // Need to decide on corner cases like all 0s
-var simplePrimTests = []struct {
+var circleContainedInTests = []struct {
+	name                                       string
 	botX, topX, botY, topY, radius, posX, posY float32
-	contExp, overlExp                          bool
+	expResult                                  bool
 }{
-	{0, 400, 0, 400, 50, 200, 200, true, true},
-	{0, 400, 0, 400, 50, 380, 380, false, true},
-	{0, 400, 0, 400, 50, 425, 425, false, true},
-	{0, 400, 0, 400, 50, 475, 475, false, false},
-	{0, 400, 0, 400, 20, 425, 425, false, false},
-	{0, 400, 0, 400, 100, 500, 400, false, true},
-	{0, 400, 0, 400, 100, 501, 400, false, false},
+	{"contained in middle", 0, 400, 0, 400, 50, 200, 200, true},
+	{"inside and overlap top right", 0, 400, 0, 400, 50, 380, 380, false},
+	{"outside and overlap top right", 0, 400, 0, 400, 50, 425, 425, false},
+	{"outside and non-overlap top right", 0, 400, 0, 400, 50, 475, 475, false},
+	{"outside and non-overlap top right small", 0, 400, 0, 400, 20, 425, 425, false},
+	{"touching right", 0, 400, 0, 400, 100, 500, 400, false},
+	{"one unit non-overlap right", 0, 400, 0, 400, 100, 501, 400, false},
 }
 
-// TestSimplePrimitive : Test basic primitive creation and
-// functionality
-func TestSimplePrimitive(t *testing.T) {
+// TestCircleContainedIn : Test circle contained in rect
+func TestCircleContainedIn(t *testing.T) {
 	var x, y float32
 	var rect Rect
 	var position mgl32.Vec3
 	var circle Circle
-	var isContained, overlaps bool
+	var isContained bool
 
 	obj := CreateObject(position)
 
-	for _, tt := range simplePrimTests {
-		obj.SetPosition(tt.posX, tt.posY)
-		circle.Radius = tt.radius
-		x, y = obj.GetPosition()
-		rect = Rect{{tt.botX, tt.botY}, {tt.topX, tt.topY}}
+	for _, tc := range circleContainedInTests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj.SetPosition(tc.posX, tc.posY)
+			circle.Radius = tc.radius
+			x, y = obj.GetPosition()
+			rect = Rect{{tc.botX, tc.botY}, {tc.topX, tc.topY}}
 
-		isContained = circle.IsContainedInRect(*obj, rect)
-		if isContained != tt.contExp {
-			t.Errorf("IsContInRect %v (exp: %v) with x (%v), y (%v), rad (%v) in x (%v-%v) and y (%v-%v)",
-				isContained, tt.contExp, x, y, circle.Radius, tt.botX, tt.topX, tt.botY, tt.topY)
-		}
+			isContained = circle.IsContainedInRect(*obj, rect)
+			if isContained != tc.expResult {
+				t.Errorf("IsContInRect %v (exp: %v) with x (%v), y (%v), rad (%v) in x (%v-%v) and y (%v-%v)",
+					isContained, tc.expResult, x, y, circle.Radius, tc.botX, tc.topX, tc.botY, tc.topY)
+			}
+		})
+	}
+}
 
-		overlaps = circle.OverlapsWithRect(*obj, rect)
-		if overlaps != tt.overlExp {
-			t.Errorf("overlapWithRect %v (exp: %v) with x (%v), y (%v), rad (%v) in x (%v-%v) and y (%v-%v)",
-				overlaps, tt.overlExp, x, y, circle.Radius, tt.botX, tt.topX, tt.botY, tt.topY)
-		}
+var circleOverlapTests = []struct {
+	name                                       string
+	botX, topX, botY, topY, radius, posX, posY float32
+	expResult                                  bool
+}{
+	{"contained in middle", 0, 400, 0, 400, 50, 200, 200, true},
+	{"inside and overlap top right", 0, 400, 0, 400, 50, 380, 380, true},
+	{"outside and overlap top right", 0, 400, 0, 400, 50, 425, 425, true},
+	{"outside and non-overlap top right", 0, 400, 0, 400, 50, 475, 475, false},
+	{"outside and non-overlap top right small", 0, 400, 0, 400, 20, 425, 425, false},
+	{"touching right", 0, 400, 0, 400, 100, 500, 400, true},
+	{"one unit non-overlap right", 0, 400, 0, 400, 100, 501, 400, false},
+}
+
+// TestCircleOverlap : Test circle overlaps with rect
+func TestCircleOverlap(t *testing.T) {
+	var x, y float32
+	var rect Rect
+	var position mgl32.Vec3
+	var circle Circle
+	var overlaps bool
+
+	obj := CreateObject(position)
+
+	for _, tc := range circleOverlapTests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj.SetPosition(tc.posX, tc.posY)
+			circle.Radius = tc.radius
+			x, y = obj.GetPosition()
+			rect = Rect{{tc.botX, tc.botY}, {tc.topX, tc.topY}}
+
+			overlaps = circle.OverlapsWithRect(*obj, rect)
+			if overlaps != tc.expResult {
+				t.Errorf("overlapWithRect %v (exp: %v) with x (%v), y (%v), rad (%v) in x (%v-%v) and y (%v-%v)",
+					overlaps, tc.expResult, x, y, circle.Radius, tc.botX, tc.topX, tc.botY, tc.topY)
+			}
+		})
+	}
+}
+
+var circleFromRendererTests = []struct {
+	name      string
+	vertices  []float32
+	expRadius float32
+}{
+	{"200 square at origin", []float32{-100, -100, 0, 0, 1, 100, 100, 0, 1, 0,
+		-100, 100, 0, 0, 0, -100, -100, 0, 0, 1,
+		100, -100, 0, 1, 1, 100, 100, 0, 1, 0}, 65,
+	},
+	{"50 triangle top right of origin", []float32{0, 0, 0, 0, 1, 50, 50, 0, 1, 0,
+		0, 50, 0, 0, 0, 0, 0, 0, 0, 1}, 16.25,
+	},
+	{"1 square", []float32{0, 0, 0, 0, 1, 1, 1, 0, 1, 0,
+		0, 1, 0, 0, 0, 0, 0, 0, 0, 1,
+		1, 0, 0, 1, 1, 1, 1, 0, 1, 0}, 0.325,
+	},
+	{"0 square", []float32{0, 0, 0, 0, 1, 0, 0, 0, 1, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+		0, 0, 0, 1, 1, 0, 0, 0, 1, 0}, 0,
+	},
+}
+
+// TestCircleFromRenderer : generates circle primitives from
+// a mocked renderer which only contains vertices
+func TestCircleFromRenderer(t *testing.T) {
+	var circle Circle
+	var renderer *opengl.MeshRenderer
+	var err error
+
+	opengl.CreateMeshRenderer = mocks.CreateVerticesOnlyMeshRendererImpl
+
+	for _, tc := range circleFromRendererTests {
+		t.Run(tc.name, func(t *testing.T) {
+			renderer, err = opengl.CreateMeshRenderer("", "", []int{}, map[int]interface{}{}, tc.vertices)
+			circle.InitFromRenderer(renderer)
+
+			if circle.Radius != tc.expRadius {
+				t.Errorf("Circle radius is (%v) should be (%v)", circle.Radius, tc.expRadius)
+			}
+		})
 	}
 }

--- a/templates_test.go
+++ b/templates_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/go-gl/mathgl/mgl32"
 	"github.com/go-test/deep"
-	"github.com/leedenison/gologo/mocks"
+	"github.com/leedenison/gologo/fakes"
 	"github.com/leedenison/gologo/opengl"
 	"github.com/leedenison/gologo/render"
 )
@@ -42,7 +42,7 @@ func TestCreateTemplateObject(t *testing.T) {
 
 	LoadObjectTemplates("testdata" + pathSeparator + "res")
 
-	opengl.CreateMeshRenderer = mocks.CreateVerticesOnlyMeshRendererImpl
+	opengl.CreateMeshRenderer = fakes.CreateVerticesOnlyMeshRendererImpl
 
 	for _, tc := range createTOTests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/testdata/res/circle_object.json
+++ b/testdata/res/circle_object.json
@@ -1,5 +1,5 @@
 {
-    "Name": "PRIM_OBJECT",
+    "Name": "CIRCLE_OBJECT",
     "PhysicsPrimitiveType": "CIRCLE",
     "PhysicsPrimitive": {
         "Radius": 50.0

--- a/testdata/res/undef_circle_object.json
+++ b/testdata/res/undef_circle_object.json
@@ -1,5 +1,5 @@
 {
-    "Name": "ZEROPRIM_OBJECT",
+    "Name": "UNDEF_CIRCLE_OBJECT",
     "PhysicsPrimitiveType": "CIRCLE",
     "RendererType": "NONE"
 }

--- a/testdata/res/undef_circle_rend_object.json
+++ b/testdata/res/undef_circle_rend_object.json
@@ -1,0 +1,18 @@
+{
+    "Name": "UNDEF_CIRCLE_REND_OBJECT",
+    "PhysicsPrimitiveType": "CIRCLE",
+    "RendererType": "MESH_RENDERER",
+    "Renderer": {
+        "VertexShader": "ORTHO_VERTEX_SHADER",
+        "FragmentShader": "COLOR_FRAGMENT_SHADER",
+        "Color": [ 0, 0, 1, 1 ],
+    	"MeshVertices": [
+            -100, -100, 0, 0, 1,
+            100, 100, 0, 1, 0,
+	        -100, 100, 0, 0, 0,
+	        -100, -100, 0, 0, 1,
+    	    100, -100, 0, 1, 1,
+    	    100, 100, 0, 1, 0
+    	]
+    }
+}


### PR DESCRIPTION
A few thoughts here:

1) I used mocks for the dir for the fake vertex only impl of createmeshrenderer and put them in the mocks package. Maybe we want to keep these separate from actual gomock mocks? Either gologo_mocks or maybe some other non mocks based naming
2) The opengl mocks file is called that because it uses the concrete definition of MeshRenderer. It also needs to return a MeshRenderer to pass to InitFromRenderer. Therefore I think this is reasonable but then I guess it breaks our idea of mocks because it depends on the very thing it's trying to "mock"